### PR TITLE
Fixing the .A deprecation involved by latest versions of Scipy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
   build-and-test: 
     docker:
       - image: cimg/python:3.10.2
+        environment:
+          LIMIT_NUMPY_VERSION: 2.0.0
+          LIMIT_SCIPY_VERSION: 1.13.1
     steps:
       - checkout
       - python/install-packages:
@@ -17,7 +20,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             pip install --upgrade pip
-            pip install --only-binary=numpy,scipy numpy==1.22.4 scipy Cython pytest pytest-cov codecov
+            pip install --only-binary=numpy,scipy "numpy<$LIMIT_NUMPY_VERSION" "scipy<=$LIMIT_SCIPY_VERSION" Cython pytest pytest-cov codecov
             pip install -e .[tests]
       - run:
           name: Run tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,14 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        versions:
-          - { python: "3.8", numpy: 1.22.4 }
-          - { python: "3.9", numpy: 1.22.4 }
-          - { python: "3.10", numpy: 1.22.4 }
-          - { python: "3.11", numpy: 1.24.3 }
-          - { python: "3.12", numpy: 1.26.4 }
-        
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    env:
+      LIMIT_NUMPY_VERSION: 2.0.0
+      LIMIT_SCIPY_VERSION: 1.13.1
     steps:
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v2
@@ -32,47 +28,47 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Setup Python ${{ matrix.versions.python }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.versions.python != '3.8') && (matrix.versions.python != '3.9')) }}
+    - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
-        python-version: ${{ matrix.versions.python }}
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
     - name: Setup Python 3.8-3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.versions.python == '3.8') || (matrix.versions.python == '3.9')) }}
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
-        brew install python@${{ matrix.versions.python }}
+        brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.versions.python }} get-pip.py
+        python${{ matrix.python-version }} get-pip.py
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.versions.python }}.exe")
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
         New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 
-        python${{ matrix.versions.python }} -c "import sys; print(sys.version)"
+        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: pip install wheel setuptools pip --upgrade
-
-    - name: Install numpy ${{ matrix.versions.numpy }}
-      run: pip install numpy==${{ matrix.versions.numpy }}
-    
-    - name: Display numpy version
-      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.python-version }} -m pip install wheel setuptools pip --upgrade
+  
+    - name: Install other dependencies
+      run: python${{ matrix.python-version }} -m pip install Cython pytest pytest-cov flake8
 
     - name: Install other dependencies
       run: |
-        pip install scipy Cython pytest pytest-cov flake8
-        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        pip install -e .[tests]
+        python${{ matrix.python-version }} -m pip install Cython pytest pytest-cov flake8 "numpy<${{ env.LIMIT_NUMPY_VERSION }}" "scipy<=${{ env.LIMIT_SCIPY_VERSION }}"
+        python${{ matrix.python-version }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
+        python${{ matrix.python-version }} -m pip install -e .[tests]
+
+    - name: Display numpy version
+      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
 
     - name: Lint with flake8
       run: |
@@ -83,4 +79,4 @@ jobs:
     
     - name: Test with pytest
       run: |
-        pytest --cov=cornac
+        python${{ matrix.python-version }} -m pytest --cov=cornac

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,10 @@ on:
   release:
     types: [published]
 
+env:
+  LIMIT_NUMPY_VERSION: 2.0.0
+  LIMIT_SCIPY_VERSION: 1.13.1
+
 jobs:
   build-wheels:
     name: Building on ${{ matrix.os }}
@@ -20,58 +24,52 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        versions:
-          - { python: "3.8", numpy: 1.22.4 }
-          - { python: "3.9", numpy: 1.22.4 }
-          - { python: "3.10", numpy: 1.22.4 }
-          - { python: "3.11", numpy: 1.24.3 }
-          - { python: "3.12", numpy: 1.26.4 }
-
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Python ${{ matrix.versions.python }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.versions.python != '3.8') && (matrix.versions.python != '3.9')) }}
+    - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
-        python-version: ${{ matrix.versions.python }}
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
     - name: Setup Python 3.8-3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.versions.python == '3.8') || (matrix.versions.python == '3.9')) }}
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
-        brew install python@${{ matrix.versions.python }}
+        brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.versions.python }} get-pip.py
+        python${{ matrix.python-version }} get-pip.py
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.versions.python }}.exe")
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
         New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 
-        python${{ matrix.versions.python }} -c "import sys; print(sys.version)"
+        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: pip install wheel setuptools pip --upgrade
+      run: python${{ matrix.python-version }} -m pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy ${{ matrix.versions.numpy }}
-      run: pip install numpy==${{ matrix.versions.numpy }}
+    - name: Install numpy, scipy
+      run: pip install "numpy<${{ env.LIMIT_NUMPY_VERSION }}" "scipy<=${{ env.LIMIT_SCIPY_VERSION }}"
     
-    - name: Display numpy version
-      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
-
     - name: Install other dependencies
       run: |
-        pip install scipy Cython wheel
+        pip install Cython wheel
     
+    - name: Display numpy version
+      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
+
     - name: Build wheels
-      run: python${{ matrix.versions.python }} setup.py bdist_wheel
+      run: python${{ matrix.python-version }} setup.py bdist_wheel
         
     - name: Rename Linux wheels to supported platform of PyPI
       if: matrix.os == 'ubuntu-latest'
@@ -105,12 +103,12 @@ jobs:
 
     - name: Install numpy
       run: |
-        python -m pip install numpy==1.22.4
+        python -m pip install "numpy<${{ env.LIMIT_NUMPY_VERSION }}" "scipy<=${{ env.LIMIT_SCIPY_VERSION }}"
         python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
-        python -m pip install scipy Cython wheel
+        python -m pip install Cython wheel
 
     - name: Build source tar file
       run: python setup.py sdist

--- a/cornac/data/text.py
+++ b/cornac/data/text.py
@@ -974,6 +974,7 @@ class TextModality(FeatureModality):
         tfidf_mat = self.tfidf_matrix[batch_ids]
         return tfidf_mat if keep_sparse else tfidf_mat.A
 
+
 class ReviewModality(TextModality):
     """Review modality
 
@@ -1034,6 +1035,7 @@ class ReviewModality(TextModality):
             Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     """
+
     def __init__(self,
                  data: List[tuple] = None,
                  group_by: str = None,

--- a/cornac/data/text.py
+++ b/cornac/data/text.py
@@ -951,7 +951,7 @@ class TextModality(FeatureModality):
         if binary:
             bow_mat.data.fill(1)
 
-        return bow_mat if keep_sparse else bow_mat.A
+        return bow_mat if keep_sparse else bow_mat.toarray()
 
     def batch_tfidf(self, batch_ids, keep_sparse=False):
         """Return matrix of TF-IDF features corresponding to provided batch_ids
@@ -972,7 +972,7 @@ class TextModality(FeatureModality):
 
         """
         tfidf_mat = self.tfidf_matrix[batch_ids]
-        return tfidf_mat if keep_sparse else tfidf_mat.A
+        return tfidf_mat if keep_sparse else tfidf_mat.toarray()
 
 
 class ReviewModality(TextModality):

--- a/cornac/datasets/__init__.py
+++ b/cornac/datasets/__init__.py
@@ -14,6 +14,7 @@
 # ============================================================================
 
 from . import amazon_clothing
+from . import amazon_digital_music
 from . import amazon_office
 from . import amazon_toy
 from . import citeulike

--- a/cornac/models/knn/recom_knn.py
+++ b/cornac/models/knn/recom_knn.py
@@ -239,7 +239,7 @@ class UserKNN(Recommender):
         if item_idx is not None:
             weighted_avg = compute_score_single(
                 True,
-                self.sim_mat[user_idx].A.ravel(),
+                self.sim_mat[user_idx].toarray().ravel(),
                 self.iu_mat.indptr[item_idx],
                 self.iu_mat.indptr[item_idx + 1],
                 self.iu_mat.indices,
@@ -251,7 +251,7 @@ class UserKNN(Recommender):
         weighted_avg = np.zeros(self.num_items)
         compute_score(
             True,
-            self.sim_mat[user_idx].A.ravel(),
+            self.sim_mat[user_idx].toarray().ravel(),
             self.iu_mat.indptr,
             self.iu_mat.indices,
             self.iu_mat.data,
@@ -412,7 +412,7 @@ class ItemKNN(Recommender):
         if item_idx is not None:
             weighted_avg = compute_score_single(
                 False,
-                self.ui_mat[user_idx].A.ravel(),
+                self.ui_mat[user_idx].toarray().ravel(),
                 self.sim_mat.indptr[item_idx],
                 self.sim_mat.indptr[item_idx + 1],
                 self.sim_mat.indices,
@@ -424,7 +424,7 @@ class ItemKNN(Recommender):
         weighted_avg = np.zeros(self.num_items)
         compute_score(
             False,
-            self.ui_mat[user_idx].A.ravel(),
+            self.ui_mat[user_idx].toarray().ravel(),
             self.sim_mat.indptr,
             self.sim_mat.indices,
             self.sim_mat.data,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<=1.26
+numpy<2.0
 scipy
 Cython
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<=1.26
 scipy
 Cython
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,7 @@ setup(
         "recommendation",
     ],
     ext_modules=extensions,
-    install_requires=["numpy", "scipy", "tqdm", "powerlaw"],
+    install_requires=["numpy<2.0.0", "scipy<=1.13.1", "tqdm", "powerlaw"],
     extras_require={"tests": ["pytest", "pytest-pep8", "pytest-xdist", "pytest-cov", "Flask"]},
     cmdclass=cmdclass,
     packages=find_packages(),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Changes involve '.A' stuff that is deprecated in latest versions of Scipy (since 1.11).
Replacing each '.A' by '.toarray()' solved the issue.

Also adding the upper bound on numpy version until 2.0 compatibility

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #628

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).

Since this is already covered by existing tests and doc, I think nothing has to be updated.
